### PR TITLE
fix: CI for 1.12

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -23,7 +23,7 @@ OptionalData = "1"
 Reexport = "1"
 Scratch = "1"
 Test = "1.6"
-julia = "1.10, 1.11"
+julia = "1.10, 1.11, 1.12"
 
 [extras]
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"

--- a/src/space_index_sets/celestrak.jl
+++ b/src/space_index_sets/celestrak.jl
@@ -62,7 +62,7 @@ function parse_files(::Type{Celestrak}, filepaths::Vector{String})
     # Store the latest processed day.
     jd_k_1 = datetime2julian(DateTime(0, 1, 1))
 
-    file = readdlm(filepath, ','; skipstart=1)
+    file = readdlm(filepath, ','; skipstart=1)::Matrix{Any}
 
     for i in 1:size(file)[1]
 

--- a/src/space_index_sets/hpo.jl
+++ b/src/space_index_sets/hpo.jl
@@ -292,10 +292,10 @@ end
 
 function _parse_hpo_forecast_json(filepath::String, n_per_day::Int)
     # Read and parse the JSON file
-    json_data = JSON.parsefile(filepath)
+    json_data = JSON.parsefile(filepath)::Dict{String, Any}
 
     # Use MEDIAN forecast values
-    median_data = json_data["MEDIAN"]
+    median_data = json_data["MEDIAN"]::Dict{String, Any}
 
     # Dictionary to accumulate data by date
     daily_data = Dict{Tuple{Int, Int, Int}, Dict{Int, Float64}}()

--- a/test/performance.jl
+++ b/test/performance.jl
@@ -8,7 +8,7 @@
 end
 
 @testset "JET Testing" begin
-    rep = JET.test_package(SpaceIndices; toplevel_logger=nothing, target_modules=(@__MODULE__,))
+    rep = JET.test_package(SpaceIndices; toplevel_logger=nothing, target_modules=(SpaceIndices,))
 end
 
 @testset "Allocations Check" begin

--- a/test/performance.jl
+++ b/test/performance.jl
@@ -11,12 +11,18 @@ end
     rep = JET.test_package(SpaceIndices; toplevel_logger=nothing, target_modules=(SpaceIndices,))
 end
 
-@testset "Allocations Check" begin
-    SpaceIndices.init()
+# Skip allocation tests on macOS with Julia 1.12+ due to AllocCheck detecting
+# platform-specific runtime calls (jl_get_pgcstack_static) as allocations
+if Sys.isapple() && (VERSION.major == 1 && VERSION.minor >= 12)
+    @warn "Allocation tests skipped on macOS with Julia 1.12+ due to AllocCheck platform limitations"
+else
+    @testset "Allocations Check" begin
+        SpaceIndices.init()
 
-    for index in _INDICES
-        @test length(check_allocs(space_index, (Val{index}, Float64))) == 0
+        for index in _INDICES
+            @test length(check_allocs(space_index, (Val{index}, Float64))) == 0
+        end
+
+        SpaceIndices.destroy()
     end
-
-    SpaceIndices.destroy()
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -43,7 +43,7 @@ if isempty(VERSION.prerelease)
     using Pkg
 
     Pkg.add("DifferentiationInterface")
-    Pkg.add("Enzyme")
+    
     Pkg.add("FiniteDiff")
     Pkg.add("ForwardDiff")
     Pkg.add("Mooncake")
@@ -54,15 +54,28 @@ if isempty(VERSION.prerelease)
     Pkg.add("JET")
     Pkg.add("AllocCheck")
 
-    # Test with Mooncake and Enzyme along with the other backends
-    using DifferentiationInterface
-    using Enzyme, FiniteDiff, ForwardDiff, Mooncake, PolyesterForwardDiff, Zygote
-    const _BACKENDS = (
-        ("ForwardDiff", AutoForwardDiff()),
-        ("Enzyme", AutoEnzyme()),
-        ("Mooncake", AutoMooncake(;config=nothing)),
-        ("PolyesterForwardDiff", AutoPolyesterForwardDiff()),
-    )
+    
+    if (VERSION.major == 1 && VERSION.minor < 12)
+        Pkg.add("Enzyme")
+        using DifferentiationInterface
+        using Enzyme, FiniteDiff, ForwardDiff, Mooncake, PolyesterForwardDiff, Zygote
+
+        const _BACKENDS = (
+            ("ForwardDiff", AutoForwardDiff()),
+            ("Enzyme", AutoEnzyme()),
+            ("Mooncake", AutoMooncake(;config=nothing)),
+            ("PolyesterForwardDiff", AutoPolyesterForwardDiff()),
+        )
+    else
+        @warn "Enzyme is not fully supported on Julia 1.12, skipping tests"
+        using DifferentiationInterface
+        using FiniteDiff, ForwardDiff, Mooncake, PolyesterForwardDiff, Zygote
+        const _BACKENDS = (
+            ("ForwardDiff", AutoForwardDiff()),
+            ("Mooncake", AutoMooncake(;config=nothing)),
+            ("PolyesterForwardDiff", AutoPolyesterForwardDiff()),
+        )
+    end
 
     @testset "Automatic Differentiation" verbose = true begin
         include("./differentiability.jl")


### PR DESCRIPTION
Enzyme is not fully supported for 1.12, so skipping for now
Small typing hints for JET
Skip Allocation check on MacOS 1.12